### PR TITLE
Add fortuneteller VS code extension to upload meta datas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.4
+
+- **Add fortuneteller**
+
 ## 1.0.3
 
 - **Add Isml Linter**

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ See an extension that you think should be included or removed? Create an [issue]
 
 - [Prophet Debugger](https://marketplace.visualstudio.com/items?itemName=SqrTT.prophet): Debugger for SCC, language support for ISML, uploader for changed files and a lot more
 
+- [fortuneteller](https://marketplace.visualstudio.com/items?itemName=ismailnguyen.fortuneteller): Salesforce Commerce Cloud aka SFCC/Demandware meta data uploader VS Code extension
+
 - [Isml Linter](https://marketplace.visualstudio.com/items?itemName=fabiowquixada.vscode-isml-linter): Enable capability to examining if your project's templates follow a specified set of rules defined for isml files.
 
 - [Require Cartridge Resolve](https://marketplace.visualstudio.com/items?itemName=pikamachu.require-cartridge-resolve): Provides definitions for Salesforce Commerce Cloud SFRA require cartridge files in your code for quick navigation and completion.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ],
     "extensionDependencies": [
         "SqrTT.prophet",
+        "ismailnguyen.fortuneteller",
         "christian-kohler.path-intellisense",
         "eamodio.gitlens",
         "finico.quickOpenSelection",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "salesforce-commerce-cloud-productivity-pack",
     "displayName": "Salesforce Commerce Cloud Productivity Pack",
     "description": "Productivity pack for Salesforce Commerce Cloud Developers",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "icon": "images/logo.png",
     "galleryBanner": {
       "color": "#2673D4",


### PR DESCRIPTION
Add "fortuneteller" VS Code extension to upload and import meta datas directly from the IDE with one command.

Source code:
https://github.com/ismailnguyen/fortuneteller

Marketplace plugin page:
https://marketplace.visualstudio.com/items?itemName=ismailnguyen.fortuneteller