### PR TITLE
Removing Beautify which is not maintained anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "eamodio.gitlens",
         "finico.quickOpenSelection",
         "formulahendry.auto-rename-tag",
-        "HookyQR.beautify",
         "nikhilkumar80.js-patterns-snippets",
         "rafamel.subtle-brackets",
         "robinbentley.sass-indented",


### PR DESCRIPTION
VSCode highlights Beautify as deprecated